### PR TITLE
Add web player authentication. Closes GH-48

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Configures what part of your world to expose:
 Configures the NetCraft web client:
 
 * `y_offset` (20): height to shift the web client blocks upwards, to distinguish from the pre-generated landscape
+* `allow_anonymous` (true): allow web users to connect without logging in, otherwise a player must first run `/websandbox auth` and click the link
 * `allow_break_place_blocks` (true): allow web users to break/place blocks, set to false for view-only (see also `allow_signs`)
 * `unbreakable_blocks` (`BEDROCK`): list of block types to deny the client from breaking or placing
 * `allow_signs` (true): allow web users to place signs (by typing backquote followed by the text)
@@ -91,11 +92,13 @@ texture pack compatibility, see [NetCraft#textures](https://github.com/satoshinm
 
 ## Commands
 
-* `/websandbox`: show help
+* `/websandbox` or `/websandbox help`: show help
 * `/websandbox list [verbose]`: list all web users connected
 * `/websandbox tp [<user>]`: teleport to given web username, or web spawn location
 * `/websandbox kick <user>`: disconnect given web username
-* `/websandbox auth [<user>]`: generates an authentication token to allow the player to authenticate over the web as themselves instead of anonymously
+* `/websandbox auth [<user>]`: generates an a web link to allow the player to authenticate over the web as themselves instead of anonymously
+
+All commands except help and auth require op, or a `websandbox.command.<command>` permission node.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Configures what part of your world to expose:
 * `z_center` (0): " ", Z coordinate
  * If x/y/z center are all 0, then the world's spawn location is used instead
 * `radius` (16): range out of the center to expose in each direction (cube), setting too high will slow down web client loading
+* `clickable_links` (true): send clickable links in chat commands from `/websandbox auth` if true, or as plain text if false
+* `clickable_links_tellraw` (false): use the `/tellraw` command to send richly formatted messages if true, or use the TextComponents API if false, change this if you get a formatting error with `/websandbox auth`
 * `entity` ("Sheep"): name of entity class to spawn on server for web users, set to "" to disable
 * `entity_custom_names` (true): add web player names to the spawned entity's nametag if true
 * `entity_disable_gravity` (true): disable gravity for the spawned entities if true
@@ -92,6 +94,7 @@ texture pack compatibility, see [NetCraft#textures](https://github.com/satoshinm
 * `/websandbox list [verbose]`: list all web users connected
 * `/websandbox tp [<user>]`: teleport to given web username, or web spawn location
 * `/websandbox kick <user>`: disconnect given web username
+* `/websandbox auth [<user>]`: generates an authentication token to allow the player to authenticate over the web as themselves instead of anonymously
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The settings are as follows:
 Configures the HTTP and WebSocket server:
 
 * `port` (4081): TCP port for the HTTP server to listen on
+* `publicURL` (http://localhost:4081/) - URL for publicly accessing this server, sent to clients when running the `/websandbox auth` command
 * `takeover` (false): advanced experimental option to reuse the server port from Bukkit (ignoring `port`) before startup, allowing this plugin to be used on hosts where only one port is allowed
 * `unbind_method` ('console.getServerConnection.b'): if `takeover` enabled, this method is called on `Bukkit.getServer()`, may need to change depending on your Bukkit server implementation
 

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/Settings.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/Settings.java
@@ -44,8 +44,6 @@ abstract public class Settings {
     public Map<String, Object> blocksToWebOverride = new HashMap<String, Object>();
     public boolean warnMissing = true;
 
-    public Map<String, String> playerAuthKeys = new HashMap<String, String>();
-
     // Automatic settings
     public String textureURL = null;
     public File pluginDataFolder = null;

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/Settings.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/Settings.java
@@ -44,6 +44,8 @@ abstract public class Settings {
     public Map<String, Object> blocksToWebOverride = new HashMap<String, Object>();
     public boolean warnMissing = true;
 
+    public Map<String, String> playerAuthKeys = new HashMap<String, String>();
+
     // Automatic settings
     public String textureURL = null;
     public File pluginDataFolder = null;

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/Settings.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/Settings.java
@@ -38,6 +38,7 @@ abstract public class Settings {
     // raised this amount in the web world, so it is clearly distinguished from the client-generated terrain
     public int y_offset = 20;
 
+    public boolean allowAnonymous = true;
     public boolean allowBreakPlaceBlocks = true;
     public List<String> unbreakableBlocks = new ArrayList<String>();
     public boolean allowSigns = true;

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/Settings.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/Settings.java
@@ -10,6 +10,7 @@ import java.util.logging.Level;
 abstract public class Settings {
     // User configurable settings
     public int httpPort = 4081;
+    public String publicURL = "http://localhost:" + httpPort + "/";
     public boolean takeover = false;
     public String unbindMethod = "console.getServerConnection.b";
 

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/Settings.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/Settings.java
@@ -31,6 +31,9 @@ abstract public class Settings {
     // of this radius, +/-
     public int radius = 16;
 
+    public boolean clickableLinks = true;
+    public boolean clickableLinksTellraw = false;
+
     // raised this amount in the web world, so it is clearly distinguished from the client-generated terrain
     public int y_offset = 20;
 

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bridge/WebPlayerBridge.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bridge/WebPlayerBridge.java
@@ -219,15 +219,22 @@ public class WebPlayerBridge {
 
     public void authenticateUser(ChannelHandlerContext ctx, String username, String token) {
         if (validateClientAuthKey(username, token)) {
-            this.channelId2name.put(ctx.channel().id(), username);
-                /* TODO: properly update other structures
-                if (this.webPlayerBridge.channelId2Entity.containsKey(ctx.channel().id())) {
-                    this.webPlayerBridge.channelId2Entity.put(ctx.channel().id(), )
-                }
-                */
+            // Rename user from the default guest name
+            ChannelId id = ctx.channel().id();
+            this.channelId2name.put(id, username);
+            Entity entity = this.channelId2Entity.get(id);
+            if (entity != null) {
+                this.entityId2Username.put(entity.getEntityId(), username);
+            }
+            this.name2channel.remove(username);
+            this.name2channel.put(username, ctx.channel());
+            // TODO: update entity custom name if has one
+
             webSocketServerThread.sendLine(ctx.channel(), "T,Successfully logged in as "+username);
         } else {
             webSocketServerThread.sendLine(ctx.channel(), "T,Invalid token, failed to login as "+username);
         }
+        // TODO: anonymous auth
+        // TODO: show "logged in" message here not earlier, since now know username!
     }
 }

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bridge/WebPlayerBridge.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bridge/WebPlayerBridge.java
@@ -43,6 +43,7 @@ public class WebPlayerBridge {
     private boolean clickableLinksTellraw;
     private String publicURL;
 
+    private boolean allowAnonymous;
     private boolean setCustomNames;
     private boolean disableGravity;
     private boolean disableAI;
@@ -78,6 +79,7 @@ public class WebPlayerBridge {
         this.clickableLinksTellraw = settings.clickableLinksTellraw;
         this.publicURL = settings.publicURL;
 
+        this.allowAnonymous = settings.allowAnonymous;
         this.lastPlayerID = 0;
         this.channelId2name = new HashMap<ChannelId, String>();
         this.channelId2Entity = new HashMap<ChannelId, Entity>();
@@ -85,7 +87,7 @@ public class WebPlayerBridge {
         this.name2channel = new HashMap<String, Channel>();
     }
 
-    public String newPlayer(final Channel channel, String proposedUsername, String token) {
+    public boolean newPlayer(final Channel channel, String proposedUsername, String token) {
         String theirName;
         if (validateClientAuthKey(proposedUsername, token)) {
             theirName = proposedUsername;
@@ -93,6 +95,11 @@ public class WebPlayerBridge {
         } else {
             if (!proposedUsername.equals("")) { // blank = anonymous
                 webSocketServerThread.sendLine(channel, "T,Failed to login as "+proposedUsername);
+            }
+
+            if (!allowAnonymous) {
+                webSocketServerThread.sendLine(channel,"T,This server requires authentication.");
+                return false;
             }
 
             int theirID = ++this.lastPlayerID;
@@ -131,8 +138,7 @@ public class WebPlayerBridge {
 
         // TODO: should this go to Bukkit chat, too/instead? make configurable?
         webSocketServerThread.broadcastLine("T," + theirName + " has joined.");
-
-        return theirName;
+        return true;
     }
 
     public void clientMoved(final Channel channel, final double x, final double y, final double z, final double rx, final double ry) {

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bridge/WebPlayerBridge.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bridge/WebPlayerBridge.java
@@ -239,7 +239,7 @@ public class WebPlayerBridge {
             Player player = (Player) sender;
 
             String linkText = "Click here to login";
-            //TODO String hoverText = "Login to the web sandbox as this user";
+            String hoverText = "Login to the web sandbox as " + player.getName();
 
             // There are two strategies since TextComponents fails with on Glowstone with an error:
             // java.lang.UnsupportedOperationException: Not supported yet.
@@ -255,17 +255,18 @@ public class WebPlayerBridge {
                 clickEventJson.put("value", url);
                 json.put("clickEvent", clickEventJson);
 
-                /* TODO
                 JSONObject hoverEventJson = new JSONObject();
                 hoverEventJson.put("action", "show_text");
-                hoverEventJson.put("value", hoverText);
-                */
+                JSONObject hoverTextObject = new JSONObject();
+                hoverTextObject.put("text", hoverText);
+                hoverEventJson.put("value", hoverTextObject);
+                json.put("hoverEvent", hoverEventJson);
 
                 Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + player.getName() + " " + json.toJSONString());
             } else {
                 TextComponent message = new TextComponent(linkText);
                 message.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url));
-                //message.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent[] { new TextComponent(hoverText) }));
+                message.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent[] { new TextComponent(hoverText) }));
                 message.setBold(true);
 
                 player.spigot().sendMessage(message);

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bridge/WebPlayerBridge.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bridge/WebPlayerBridge.java
@@ -6,6 +6,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelId;
 import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -40,6 +41,7 @@ public class WebPlayerBridge {
     private Map<String, String> playerAuthKeys = new HashMap<String, String>();
     private boolean clickableLinks;
     private boolean clickableLinksTellraw;
+    private String publicURL;
 
     private boolean setCustomNames;
     private boolean disableGravity;
@@ -74,6 +76,7 @@ public class WebPlayerBridge {
 
         this.clickableLinks = settings.clickableLinks;
         this.clickableLinksTellraw = settings.clickableLinksTellraw;
+        this.publicURL = settings.publicURL;
 
         this.lastPlayerID = 0;
         this.channelId2name = new HashMap<ChannelId, String>();
@@ -230,10 +233,13 @@ public class WebPlayerBridge {
         // TODO: persist to disk
 
 
-        String url = "http://localhost:4081/#++" + username + "+" + token;
+        String url = publicURL + "#++" + username + "+" + token;
 
         if (clickableLinks && sender instanceof Player) {
             Player player = (Player) sender;
+
+            String linkText = "Click here to login";
+            //TODO String hoverText = "Login to the web sandbox as this user";
 
             // There are two strategies since TextComponents fails with on Glowstone with an error:
             // java.lang.UnsupportedOperationException: Not supported yet.
@@ -241,7 +247,7 @@ public class WebPlayerBridge {
             // see https://github.com/GlowstoneMC/Glowkit-Legacy/pull/8
             if (clickableLinksTellraw) {
                 JSONObject json = new JSONObject();
-                json.put("text", "Click here to login");
+                json.put("text", linkText);
                 json.put("bold", true);
 
                 JSONObject clickEventJson = new JSONObject();
@@ -249,10 +255,17 @@ public class WebPlayerBridge {
                 clickEventJson.put("value", url);
                 json.put("clickEvent", clickEventJson);
 
+                /* TODO
+                JSONObject hoverEventJson = new JSONObject();
+                hoverEventJson.put("action", "show_text");
+                hoverEventJson.put("value", hoverText);
+                */
+
                 Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + player.getName() + " " + json.toJSONString());
             } else {
-                TextComponent message = new TextComponent("Click here to login");
+                TextComponent message = new TextComponent(linkText);
                 message.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url));
+                //message.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent[] { new TextComponent(hoverText) }));
                 message.setBold(true);
 
                 player.spigot().sendMessage(message);

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/SettingsBukkit.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/SettingsBukkit.java
@@ -21,6 +21,7 @@ public class SettingsBukkit extends Settings {
         config.options().copyDefaults(true);
 
         config.addDefault("http.port", this.httpPort);
+        config.addDefault("http.publicURL", this.publicURL);
         config.addDefault("http.takeover", this.takeover);
         config.addDefault("http.unbind_method", this.unbindMethod);
 
@@ -53,6 +54,7 @@ public class SettingsBukkit extends Settings {
         config.addDefault("nc.warn_missing_blocks_to_web", this.warnMissing);
 
         this.httpPort = plugin.getConfig().getInt("http.port");
+        this.publicURL = plugin.getConfig().getString("http.publicURL");
         this.takeover = plugin.getConfig().getBoolean("http.takeover");
         this.unbindMethod = plugin.getConfig().getString("http.unbind_method");
 

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/SettingsBukkit.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/SettingsBukkit.java
@@ -42,6 +42,7 @@ public class SettingsBukkit extends Settings {
         config.addDefault("mc.clickable_links_tellraw", this.clickableLinksTellraw);
 
         config.addDefault("nc.y_offset", this.y_offset);
+        config.addDefault("nc.allow_anonymous", this.allowAnonymous);
         config.addDefault("nc.allow_break_place_blocks", this.allowBreakPlaceBlocks);
         this.unbreakableBlocks.add("BEDROCK");
         config.addDefault("nc.unbreakable_blocks", this.unbreakableBlocks);
@@ -79,6 +80,7 @@ public class SettingsBukkit extends Settings {
 
         this.y_offset = plugin.getConfig().getInt("nc.y_offset");
 
+        this.allowAnonymous = plugin.getConfig().getBoolean("nc.allow_anonymous");
         this.allowBreakPlaceBlocks = plugin.getConfig().getBoolean("nc.allow_break_place_blocks");
         this.unbreakableBlocks = plugin.getConfig().getStringList("nc.unbreakable_blocks");
         this.allowSigns = plugin.getConfig().getBoolean("nc.allow_signs");

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/SettingsBukkit.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/SettingsBukkit.java
@@ -37,6 +37,8 @@ public class SettingsBukkit extends Settings {
         config.addDefault("mc.y_center", this.y_center);
         config.addDefault("mc.z_center", this.z_center);
         config.addDefault("mc.radius", this.radius);
+        config.addDefault("mc.clickable_links", this.clickableLinks);
+        config.addDefault("mc.clickable_links_tellraw", this.clickableLinksTellraw);
 
         config.addDefault("nc.y_offset", this.y_offset);
         config.addDefault("nc.allow_break_place_blocks", this.allowBreakPlaceBlocks);
@@ -69,6 +71,9 @@ public class SettingsBukkit extends Settings {
         this.y_center = plugin.getConfig().getInt("mc.y_center");
         this.z_center = plugin.getConfig().getInt("mc.z_center");
         this.radius = plugin.getConfig().getInt("mc.radius");
+
+        this.clickableLinks = plugin.getConfig().getBoolean("mc.clickable_links");
+        this.clickableLinksTellraw = plugin.getConfig().getBoolean("mc.clickable_links_tellraw");
 
         this.y_offset = plugin.getConfig().getInt("nc.y_offset");
 

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/WsCommand.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/WsCommand.java
@@ -6,6 +6,7 @@ import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
@@ -116,14 +117,33 @@ public class WsCommand implements CommandExecutor {
                 return true;
             }
 
-            sender.sendMessage("Kicking web client "+name);
-            webSocketServerThread.sendLine(channel,"T,You were kicked by "+sender.getName());
+            sender.sendMessage("Kicking web client " + name);
+            webSocketServerThread.sendLine(channel, "T,You were kicked by " + sender.getName());
             webSocketServerThread.webPlayerBridge.clientDisconnected(channel);
             return true;
+        } else if (subcommand.equals("auth")) {
+            // TODO: non-ops should be able to run this command by default
+            String name;
+
+            if (!(sender instanceof Player)) {
+                if (split.length < 2) {
+                    sender.sendMessage("Usage: /websandbox auth <user>");
+                    return true;
+                }
+                name = split[1];
+            } else {
+                Player player = (Player) sender;
+                name = player.getName();
+            }
+
+            String key = webSocketServerThread.newClientAuthKey(name);
+            sender.sendMessage("Authentication key: " + key); // TODO: link
+
         } else { // help
             sender.sendMessage("/websandbox list [verbose] -- list all web users connected");
             sender.sendMessage("/websandbox tp [<user>] -- teleport to given web username, or web spawn location");
             sender.sendMessage("/websandbox kick <user> -- disconnect given web username");
+            sender.sendMessage("/websandbox auth [<user>] -- get authentication token to login non-anonymously");
             // TODO: reload, reconfig commands
         }
         return false;

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/WsCommand.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/WsCommand.java
@@ -136,9 +136,9 @@ public class WsCommand implements CommandExecutor {
                 name = player.getName();
             }
 
-            String key = webSocketServerThread.newClientAuthKey(name);
+            String key = webSocketServerThread.webPlayerBridge.newClientAuthKey(name);
             sender.sendMessage("Authentication key: " + key); // TODO: link
-
+            return true;
         } else { // help
             sender.sendMessage("/websandbox list [verbose] -- list all web users connected");
             sender.sendMessage("/websandbox tp [<user>] -- teleport to given web username, or web spawn location");

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/WsCommand.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/WsCommand.java
@@ -27,8 +27,8 @@ public class WsCommand implements CommandExecutor {
         if (sender instanceof Player) {
             Player player = (Player) sender;
             if (!usePermissions) {
-                if (!player.isOp()) {
-                    sender.sendMessage("/websandbox requires op");
+                if (!player.isOp() && !subcommand.equals("auth") && !subcommand.equals("help")) {
+                    sender.sendMessage("This /websandbox subcommand requires op");
                     return true;
                 }
             } else {

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/WsCommand.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/WsCommand.java
@@ -138,27 +138,7 @@ public class WsCommand implements CommandExecutor {
                 name = player.getName();
             }
 
-            String key = webSocketServerThread.webPlayerBridge.newClientAuthKey(name);
-            String url = "http://localhost:4081/#-%20-%20-" + name + "%20" + key;
-
-            if (sender instanceof Player) {
-                /* TODO: fails java.lang.UnsupportedOperationException: Not supported yet.
-        at org.bukkit.entity.Player$Spigot.sendMessage(Player.java:1734)
-        see https://github.com/GlowstoneMC/Glowkit-Legacy/pull/8
-
-
-                TextComponent message = new TextComponent("Set authentication key " + key + ", click here to login");
-                message.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url));
-
-                Player player = (Player) sender;
-                player.spigot().sendMessage(message);
-                */
-
-                sender.sendMessage("Set authentication key: " + url);
-
-            } else {
-                sender.sendMessage("Set authentication key: " + url);
-            }
+            webSocketServerThread.webPlayerBridge.newClientAuthKey(name, sender);
 
             return true;
         } else { // help

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/WsCommand.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/bukkit/WsCommand.java
@@ -2,6 +2,8 @@ package io.github.satoshinm.WebSandboxMC.bukkit;
 
 import io.github.satoshinm.WebSandboxMC.ws.WebSocketServerThread;
 import io.netty.channel.Channel;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -137,7 +139,27 @@ public class WsCommand implements CommandExecutor {
             }
 
             String key = webSocketServerThread.webPlayerBridge.newClientAuthKey(name);
-            sender.sendMessage("Authentication key: " + key); // TODO: link
+            String url = "http://localhost:4081/#-%20-%20-" + name + "%20" + key;
+
+            if (sender instanceof Player) {
+                /* TODO: fails java.lang.UnsupportedOperationException: Not supported yet.
+        at org.bukkit.entity.Player$Spigot.sendMessage(Player.java:1734)
+        see https://github.com/GlowstoneMC/Glowkit-Legacy/pull/8
+
+
+                TextComponent message = new TextComponent("Set authentication key " + key + ", click here to login");
+                message.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url));
+
+                Player player = (Player) sender;
+                player.spigot().sendMessage(message);
+                */
+
+                sender.sendMessage("Set authentication key: " + url);
+
+            } else {
+                sender.sendMessage("Set authentication key: " + url);
+            }
+
             return true;
         } else { // help
             sender.sendMessage("/websandbox list [verbose] -- list all web users connected");

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/ws/WebSocketFrameHandler.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/ws/WebSocketFrameHandler.java
@@ -32,25 +32,6 @@ public class WebSocketFrameHandler extends SimpleChannelInboundHandler<WebSocket
     }
 
     @Override
-    @SuppressWarnings("deprecation") // TODO: why is HANDSHAKE_COMPLETE deprecated and what is the replacement?
-    public void userEventTriggered(final ChannelHandlerContext ctx, Object evt) throws Exception {
-        webSocketServerThread.log(Level.FINEST, "userEventTriggered: "+evt);
-        if (evt == WebSocketServerProtocolHandler.ServerHandshakeStateEvent.HANDSHAKE_COMPLETE) {
-            // "The Handshake was complete successful and so the channel was upgraded to websockets"
-
-            // Since we're in a callback we cannot call any Bukkit API safely here, see:
-            // http://bukkit.gamepedia.com/Scheduler_Programming#Tips_for_thread_safety
-            // " Warning:	Asynchronous tasks should never access any API in Bukkit"
-            webSocketServerThread.scheduleSyncTask(new Runnable() {
-                @Override
-                public void run() {
-                    webSocketServerThread.handleNewClient(ctx);
-                }
-            });
-        }
-    }
-
-    @Override
     public void channelRead0(final ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
         webSocketServerThread.log(Level.FINEST, "channel read, frame="+frame);
 

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/ws/WebSocketServerThread.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/ws/WebSocketServerThread.java
@@ -177,7 +177,25 @@ N,1,guest1
     // TODO: cleanup clients when they disconnect
 
     public void handle(String string, ChannelHandlerContext ctx) {
-        if (string.startsWith("B,")) {
+        if (string.startsWith("A,")) {
+            String[] array = string.trim().split(",");
+            if (array.length != 3) {
+                throw new RuntimeException("malformed authentication command A from client: "+string);
+            }
+            String username = array[1];
+            String token = array[2];
+            if (validateClientAuthKey(username, token)) {
+                this.webPlayerBridge.channelId2name.put(ctx.channel().id(), username);
+                /* TODO: properly update other structures
+                if (this.webPlayerBridge.channelId2Entity.containsKey(ctx.channel().id())) {
+                    this.webPlayerBridge.channelId2Entity.put(ctx.channel().id(), )
+                }
+                */
+                sendLine(ctx.channel(), "T,Successfully logged in as "+username);
+            } else {
+                sendLine(ctx.channel(), "T,Invalid token, failed to login as "+username);
+            }
+        } else if (string.startsWith("B,")) {
             this.log(Level.FINEST, "client block update: "+string);
             String[] array = string.trim().split(",");
             if (array.length != 5) {

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/ws/WebSocketServerThread.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/ws/WebSocketServerThread.java
@@ -37,8 +37,6 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
-import java.math.BigInteger;
-import java.security.SecureRandom;
 import java.util.logging.Level;
 
 /**
@@ -184,17 +182,7 @@ N,1,guest1
             }
             String username = array[1];
             String token = array[2];
-            if (validateClientAuthKey(username, token)) {
-                this.webPlayerBridge.channelId2name.put(ctx.channel().id(), username);
-                /* TODO: properly update other structures
-                if (this.webPlayerBridge.channelId2Entity.containsKey(ctx.channel().id())) {
-                    this.webPlayerBridge.channelId2Entity.put(ctx.channel().id(), )
-                }
-                */
-                sendLine(ctx.channel(), "T,Successfully logged in as "+username);
-            } else {
-                sendLine(ctx.channel(), "T,Invalid token, failed to login as "+username);
-            }
+            webPlayerBridge.authenticateUser(ctx, username, token);
         } else if (string.startsWith("B,")) {
             this.log(Level.FINEST, "client block update: "+string);
             String[] array = string.trim().split(",");
@@ -242,23 +230,5 @@ N,1,guest1
         }
 
         // TODO: handle more client messages
-    }
-
-    private final SecureRandom random = new SecureRandom();
-
-    public String newClientAuthKey(String playerName) {
-        String key = new BigInteger(130, random).toString(32);
-
-        settings.playerAuthKeys.put(playerName, key);
-
-        return key;
-        // TODO: persist to disk
-    }
-
-    public boolean validateClientAuthKey(String playerName, String key) {
-        String expectedKey = settings.playerAuthKeys.get(playerName);
-        if (expectedKey == null) return false;
-        return expectedKey.equals(key);
-        // TODO: load from disk
     }
 }

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/ws/WebSocketServerThread.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/ws/WebSocketServerThread.java
@@ -37,6 +37,8 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
+import java.math.BigInteger;
+import java.security.SecureRandom;
 import java.util.logging.Level;
 
 /**
@@ -222,5 +224,23 @@ N,1,guest1
         }
 
         // TODO: handle more client messages
+    }
+
+    private final SecureRandom random = new SecureRandom();
+
+    public String newClientAuthKey(String playerName) {
+        String key = new BigInteger(130, random).toString(32);
+
+        settings.playerAuthKeys.put(playerName, key);
+
+        return key;
+        // TODO: persist to disk
+    }
+
+    public boolean validateClientAuthKey(String playerName, String key) {
+        String expectedKey = settings.playerAuthKeys.get(playerName);
+        if (expectedKey == null) return false;
+        return expectedKey.equals(key);
+        // TODO: load from disk
     }
 }

--- a/src/main/java/io/github/satoshinm/WebSandboxMC/ws/WebSocketServerThread.java
+++ b/src/main/java/io/github/satoshinm/WebSandboxMC/ws/WebSocketServerThread.java
@@ -116,7 +116,8 @@ public final class WebSocketServerThread extends Thread {
                 Channel ch = b.bind(PORT).sync().channel();
 
                 log(Level.INFO, "Open your web browser and navigate to " +
-                        (SSL ? "https" : "http") + "://127.0.0.1:" + PORT + "/");
+                        (SSL ? "https" : "http") + "://127.0.0.1:" + PORT + "/" +
+                        " or " + settings.publicURL);
 
                 ch.closeFuture().sync();
             } catch (InterruptedException ex) {

--- a/src/main/resources-filtered/plugin.yml
+++ b/src/main/resources-filtered/plugin.yml
@@ -4,4 +4,4 @@ version: ${version}
 commands:
     websandbox:
         description: Controls the WebSandbox WebGL HTML5 web interface.
-        usage: "Usage: /websandbox list|tp|kick"
+        usage: "Usage: /websandbox list|tp|kick|auth"


### PR DESCRIPTION
https://github.com/satoshinm/WebSandboxMC/issues/48

- [x] Player command to get an authentication key (/websandbox auth)
- [x] Accept the key on the client - https://github.com/satoshinm/NetCraft/pull/164
- [x] Recognize the key on the server and set to matching player username
- [x] Clickable link send to client on /websandbox auth
- [x] allow_anonymous config option, to set to false for requiring authentication
