### PR TITLE
Update to SpigotAPI 1.16.4-R0.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
       <version>${netty.version}</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1.1</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -95,6 +101,12 @@
                   <pattern>io.netty</pattern>
                   <shadedPattern>
                     io.github.satoshinm.WebSandboxMC.dep.io.netty
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.json.simple</pattern>
+                  <shadedPattern>
+                    io.github.satoshinm.WebSandboxMC.dep.org.json.simple
                   </shadedPattern>
                 </relocation>
               </relocations>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.12-R0.1-SNAPSHOT</version>
+      <version>1.16.4-R0.1-SNAPSHOT</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
1.16.4-R0.1-SNAPSHOT is currently the latest API version on https://hub.spigotmc.org/nexus/content/repositories/snapshots/org/spigotmc/spigot-api/